### PR TITLE
fix(web): build fail cause of any typed `this`

### DIFF
--- a/apps/web/src/app/(main)/explore/[sourceId]/_components/search-source-form.tsx
+++ b/apps/web/src/app/(main)/explore/[sourceId]/_components/search-source-form.tsx
@@ -12,7 +12,6 @@ export function SearchSourceForm({
 
   return (
     <Input
-      className="pr-10"
       onChange={(e) => debouncedOnSearch(e.target.value)}
       placeholder="Search novels..."
     />

--- a/apps/web/src/lib/hooks/use-debounced.ts
+++ b/apps/web/src/lib/hooks/use-debounced.ts
@@ -1,7 +1,7 @@
 function useDebounced<T>(func: (...args: T[]) => void, delay = 500) {
   let timeoutId: ReturnType<typeof setTimeout> | null = null
 
-  return function (...args: T[]) {
+  return function (this: unknown, ...args: T[]) {
     clearTimeout(timeoutId || undefined)
 
     timeoutId = setTimeout(() => {


### PR DESCRIPTION
This PR request fixes any typed `this` on the `useDebounce` hook in #6.

This error breaks the docker image build in the `validating types` step of the Next.js build process.